### PR TITLE
feat(install): drop privileges instead of exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,6 @@ Options:
 ### End users
 The target user is always module **end-user** who makes something with `node_modules` and doesn't make packages. And the goal of this project is to **reproduce** most of the features that the end-users use to build their stuff on daily basis.
 
-### Right permission
-To avoid from the risks related the lifecycle install scripts of the package while installing, dep doesn't allow you to run them if you are running `dep install` as a root user.
-
 ### Save spaces
 Speed and local disk capacity are a trade-off. To take the both benefits, it would be better to have the cache in somewhere proxy layer instead of local.
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -5,6 +5,7 @@ const saver = require('./install/saver')
 const nodeGyp = require('./utils/node-gyp')
 const rimraf = require('rimraf')
 const nm = require('./utils/nm')
+const dropPrivilege = require('./utils/drop-privilege')
 
 global.dependenciesCount = 0
 global.dependenciesTree = {}
@@ -43,6 +44,7 @@ const install = (argv) => {
   const list = resolver(deps)
   process.stdout.write('Resolving dependencies\n')
   Promise.all(list).then(() => {
+    dropPrivilege() // if root
     const tasks = installer(global.dependenciesTree)
     process.stdout.write('Installing dependencies\n')
     rimraf.sync(nm)

--- a/lib/install/installer.js
+++ b/lib/install/installer.js
@@ -9,7 +9,6 @@ const local = require('./installer/local')
 const remote = require('./installer/remote')
 const registry = require('./installer/registry')
 const runner = require('../run/runner')
-const isRoot = require('is-root')
 
 const installer = (dep, deps, base, resolve, reject) => {
   mkdirp.sync(nm)
@@ -43,12 +42,6 @@ const installer = (dep, deps, base, resolve, reject) => {
 
   fetch.then(() => {
     return new Promise((resolve, reject) => {
-      if (isRoot()) {
-        process.stdout.write(
-          'dep does not allow root users to run the install lifecycle scripts'
-        )
-        return resolve()
-      }
       const args = ['install']
       const pkg = require(path.join(target, 'package.json'))
       if (!pkg.scripts || (

--- a/lib/utils/drop-privilege.js
+++ b/lib/utils/drop-privilege.js
@@ -1,0 +1,12 @@
+const isRoot = require('is-root')
+
+module.exports = () => {
+  if (!isRoot()) return
+
+  const user = process.platform === 'win32' ? 0
+    : process.env.SUDO_UID || 'nobody'
+  const group = process.platform === 'win32' ? 0
+    : process.env.SUDO_GID || (process.getgid && process.getgid())
+  try { process.setuid(user) } catch (e) {}
+  try { process.setgid(group) } catch (e) {}
+}


### PR DESCRIPTION
As @strugee mentioned, a better way to manage the root's privileges is to just drop privileges to non-root user. The default is `process.env.SUDO_UID` if it exists, otherwise `nobody`.

Refs: https://github.com/npm/npm/blob/d46015256941ddfff1463338e3e2f8f77624a1ff/lib/config/set-user.js#L17
Fixes: https://github.com/watilde/dep/issues/1