### PR TITLE
fix(install): read package.json in the method

### DIFF
--- a/lib/install/saver.js
+++ b/lib/install/saver.js
@@ -1,9 +1,9 @@
 const fs = require('fs')
 const path = require('path')
 const npmrc = require('../utils/npmrc')
-const pkgJSON = require(path.join(process.cwd(), 'package.json'))
 
 module.exports = (pkgs, save) => {
+  const pkgJSON = require(path.join(process.cwd(), 'package.json'))
   var saveDeps = {}
   pkgs.forEach((pkg) => {
     const key = pkg.split('@')[0]


### PR DESCRIPTION
`require(package.json)` should be triggered when it's needed. If it's put out of the function, it's called regardless of whether it is necessary or not.

Fixes: https://github.com/watilde/dep/issues/5