### PR TITLE
fix(install): escape the name of scoped packages

### DIFF
--- a/lib/install/resolver/fetchers/registry.js
+++ b/lib/install/resolver/fetchers/registry.js
@@ -4,7 +4,7 @@ const npmrc = require('../../../utils/npmrc')
 module.exports = (name, spec, result) => {
   return new Promise((resolve, reject) => {
     const options = {
-      url: npmrc.registry + name + '/' + spec,
+      url: npmrc.registry + result.escapedName + '/' + spec,
       headers: {
         'User-Agent': npmrc.userAgent
       }

--- a/lib/lock/resolver.js
+++ b/lib/lock/resolver.js
@@ -7,9 +7,28 @@ const nm = require('../utils/nm')
 
 const resolver = (dep, base, resolve, reject) => {
   base = base || nm
+  if (dep.startsWith('@') && dep.indexOf('/') === -1) {
+    const dir = path.join(base, dep)
+    if (fs.existsSync(dir)) {
+      const deps = readdirSync(dir).filter((n) => {
+        return n[0] !== '.'
+      }).map((n) => {
+        return dep + '/' + n
+      })
+      const tasks = deps.map((dep) => {
+        return new Promise((resolve, reject) => resolver(dep, base, resolve, reject))
+      })
+      Promise.all(tasks).then(() => {
+        resolve()
+      }).catch(reject)
+    } else {
+      resolve()
+    }
+    return
+  }
   const pkgJSON = require(path.join(base, dep, 'package.json'))
   const options = {
-    url: npmrc.registry + pkgJSON.name + '/' + pkgJSON.version,
+    url: npmrc.registry + pkgJSON.name.replace('/', '%2f') + '/v' + pkgJSON.version,
     headers: {
       'User-Agent': npmrc.userAgent
     }
@@ -47,7 +66,7 @@ const resolver = (dep, base, resolve, reject) => {
         })
         Promise.all(tasks).then(() => {
           resolve()
-        })
+        }).catch(reject)
       } else {
         resolve()
       }

--- a/test/deps/registry-scope/package.json
+++ b/test/deps/registry-scope/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "name": "install-scope",
+  "version": "1.0.0",
+  "dependencies": {
+    "@watilde/hello-scoped-package": "^1.0.1"
+  }
+}


### PR DESCRIPTION
The slash in the name of the scoped should be escaped when dep fetches the data to the registry.

Fixes: https://github.com/watilde/dep/issues/9