### PR TITLE
fix(install): change the permission of bin file

### DIFF
--- a/lib/install/installer/bin.js
+++ b/lib/install/installer/bin.js
@@ -14,6 +14,7 @@ const bin = (key, target) => {
       path.join(target, pkgJSON.bin),
       path.join(nm, '.bin', key)
     )
+    fs.chmodSync(path.join(target, pkgJSON.bin), '0755')
   } else if (typeof pkgJSON.bin === 'object') {
     Object.keys(pkgJSON.bin).forEach((cmd) => {
       try {
@@ -23,6 +24,7 @@ const bin = (key, target) => {
         path.join(target, pkgJSON.bin[cmd]),
         path.join(nm, '.bin', cmd)
       )
+      fs.chmodSync(path.join(target, pkgJSON.bin[cmd]), '0755')
     })
   }
 }


### PR DESCRIPTION
While making the symlinks of the bin files, dep will update the permission of them to executable `0755` since it's supposed to be called as a command.

Fixes: https://github.com/watilde/dep/issues/22